### PR TITLE
add wp cli command to migrate account information

### DIFF
--- a/cc-global-network.php
+++ b/cc-global-network.php
@@ -82,6 +82,9 @@ if ( defined( 'CCGN_DEVELOPMENT' ) || defined( 'CCGN_TESTING' ) ) {
     require_once(CCGN_PATH . 'testing/reset-state.php');
 }
 
+require_once CCGN_PATH  . '/includes/class-ccgn-cli.php';
+
+
 ////////////////////////////////////////////////////////////////////////////////
 // CAS / WordPress registration
 ////////////////////////////////////////////////////////////////////////////////

--- a/cron/remove-marked-users.php
+++ b/cron/remove-marked-users.php
@@ -31,7 +31,8 @@ function ccgn_close_and_remove_retention_data_applicant($applicant_id)
     delete_user_meta($applicant_id, CCGN_APPLICATION_TYPE);
     delete_user_meta($applicant_id, CCGN_APPLICATION_STATE);
     delete_user_meta($applicant_id, CCGN_USER_IS_AUTOVOUCHED);
-
+    
+    require_once(ABSPATH.'wp-admin/includes/user.php');
     $delete = wp_delete_user($applicant_id);
 }
 

--- a/includes/class-ccgn-cli.php
+++ b/includes/class-ccgn-cli.php
@@ -1,0 +1,89 @@
+<?php
+
+class CCGN_cli {
+  /**
+   * Move the account data to a new one
+   * WARNING! please make sure the user IDs are correct before executing this command
+   * it replaces referenced user IDs and this could cause
+   * several errors with user accounts
+   * 
+   * ## OPTIONS
+   * --from=<original user id>
+   * The original user ID is the old account ID or the one we're going to gather the
+   * data in order to move it to another
+   * 
+   * --to=<target user id>
+   * The new account user id where the data is going to move
+   */
+  function move_account( $args, $assoc_args) {
+    if (!empty($assoc_args['from'] && !empty($assoc_args['to']))) {
+      WP_CLI::log('Moving data from user ID:  '. $assoc_args['from'] .' to'. $assoc_args['to']);
+      $this->link_old_entries( $assoc_args );
+      //set user type
+      $this->set_user_type( $assoc_args );
+      //set user_roles
+      $this->set_user_roles( $assoc_args );
+      $this->switch_nicenames( $assoc_args );
+      ccgn_create_profile( intval( $assoc_args['to'] ) );
+
+      _ccgn_registration_user_set_stage( intval( $assoc_args['to'] ), CCGN_APPLICATION_STATE_ACCEPTED );
+      
+      WP_CLI::success( 'Profile moved' );
+
+    } else {
+      WP_CLI::error( 'You need to set --from and --to parameters' );
+    }
+  }
+  private function link_old_entries( $assoc_args ) {
+    //refered as a voucher on position 1
+      ccgn_link_refering_entries_to_new_user( intval( $assoc_args['from'] ),"Choose Vouchers", 1, intval( $assoc_args['to'] ) );
+      //refered as a voucher on position 2
+      ccgn_link_refering_entries_to_new_user( intval( $assoc_args['from'] ),"Choose Vouchers", 2, intval( $assoc_args['to'] ) );
+      ccgn_link_refering_entries_to_new_user( intval( $assoc_args['from'] ),"Vouch for Applicant", 7, intval( $assoc_args['to'] ) );
+      ccgn_link_refering_entries_to_new_user( intval( $assoc_args['from'] ),"Vote on Membership", 4, intval( $assoc_args['to'] ) );
+      //if we pass a number to the form name, we get all the matching fields from all forms
+      ccgn_link_entries_by_user_to_new_user( intval( $assoc_args['from'] ), 0, intval( $assoc_args['to'] ) );
+  }
+  private function switch_nicenames( $assoc_args ) {
+    $current_nicename = get_userdata( intval( $assoc_args['from'] ) )->user_nicename;
+    $update_old_user = wp_update_user( array( 'ID' => intval( $assoc_args[ 'from' ] ), 'user_nicename' => $current_nicename.'-'.wp_generate_password(6,false) ) );
+    $update_new_user = wp_update_user( array( 'ID' => intval( $assoc_args[ 'to' ] ), 'user_nicename' => $current_nicename ) );
+    if ( !is_wp_error( $update_new_user ) ) {
+      WP_CLI::success( 'Nicename updated' );
+    } else {
+      WP_CLI::error( "Couldn't update nicename" );
+    }
+  }
+  private function set_user_roles( $assoc_args ) {
+    $current_roles = get_userdata( intval( $assoc_args['from'] ) )->roles;
+    $new_user_roles = get_userdata( intval( $assoc_args['to'] ) )->roles;
+    $new_user = new WP_User( intval( $assoc_args['to'] ) );
+    foreach ($new_user_roles as $role) {
+      $new_user->remove_role( $role );
+    }
+    foreach ( $current_roles as $role ) {
+      $new_user->add_role( $role );
+    }
+    $new_roles = get_userdata( intval( $assoc_args['to'] ) )->roles;
+    if ( $new_roles === $current_roles ) {
+      WP_CLI::success( 'Roles updated' );
+    } else {
+      WP_CLI::error( "Couldn't update roles" );
+    }
+  }
+  private function set_user_type( $assoc_args ) {
+    $origin_user_type = ccgn_applicant_type_desc( intval( $assoc_args['from'] ) );
+    if ( $origin_user_type == 'Individual' ) {
+      ccgn_user_set_individual_applicant( intval( $assoc_args['to'] ) );
+      ccgn_user_level_set_member_individual( intval( $assoc_args['to'] ) );
+    } else if ( $origin_user_type == 'Institution' ) {
+      ccgn_user_set_institutional_applicant( intval( $assoc_args['to'] ) );
+      ccgn_user_level_set_member_institution( intval( $assoc_args['to'] ) );
+    }
+  }
+}
+
+function ccgn_cli_register_commands() {
+  WP_CLI::add_command( 'ccgn', 'CCGN_cli' );
+}
+add_action( 'cli_init', 'ccgn_cli_register_commands' );


### PR DESCRIPTION
## Description
This PR adds a WP CLI commando to move data between accounts. This is intended to use when a current member needs to change the email address. We rely on CCID so we can't just change the email address because it won't work.
The best thing to do is moving the data from gravity forms and buddypress to a new user account.

## Technical details
Usage:
```
wp ccgn move_account --from=<source user ID> --to=<target user ID>
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
